### PR TITLE
Add split joycon mode and graphics filtering options

### DIFF
--- a/src/common/GameValues.cpp
+++ b/src/common/GameValues.cpp
@@ -252,6 +252,10 @@ void CGameValues::init()
         playerInput.inputControls[iPlayer] = &inputConfiguration[iPlayer][0];
 #endif
     }
+#ifdef __SWITCH__
+    singleJoyconMode = false;
+    filtering = false;
+#endif
 }
 
 void CGameValues::resetGameplaySettings()
@@ -434,6 +438,11 @@ void CGameValues::ReadBinaryConfig() {
         worldgraphicspacklist->SetCurrent(options.read_u8());
         gamegraphicspacklist->SetCurrent(options.read_u8());
 
+#ifdef __SWITCH__
+        singleJoyconMode = options.read_bool();
+        filtering = options.read_bool();
+#endif
+
         sfx_setmusicvolume(musicvolume);
         sfx_setsoundvolume(soundvolume);
     }
@@ -586,6 +595,12 @@ void CGameValues::WriteConfig()
         options.write_u8(menugraphicspacklist->GetCurrentIndex());
         options.write_u8(worldgraphicspacklist->GetCurrentIndex());
         options.write_u8(gamegraphicspacklist->GetCurrentIndex());
+
+#ifdef __SWITCH__
+        options.write_bool(singleJoyconMode);
+        options.write_bool(filtering);
+#endif
+
     }
     catch (std::exception const& error)
     {

--- a/src/common/GameValues.h
+++ b/src/common/GameValues.h
@@ -285,6 +285,10 @@ public:
     short		unlocksecret3part1[4];
     short		unlocksecret3part2[4];
     bool		unlocksecretunlocked[4];
+#ifdef __SWITCH__
+    bool        singleJoyconMode;
+    bool        filtering;
+#endif
 };
 
 #endif // GAMEVALUES_H

--- a/src/common/ui/MI_SelectField.cpp
+++ b/src/common/ui/MI_SelectField.cpp
@@ -234,7 +234,12 @@ MenuCodeEnum MI_SelectField::SendInput(CPlayerInput * playerInput)
         if (fFastScroll && playerInput->outputControls[iPlayer].menu_scrollfast.fDown)
             iNumMoves = 10;
 
+#ifdef __SWITCH__
+        // prevent split joycon option from flickering when enabling/disabling split joycon mode
+        if (playerInput->outputControls[iPlayer].menu_right.fPressed) {
+#else
         if (playerInput->outputControls[iPlayer].menu_right.fPressed || playerInput->outputControls[iPlayer].menu_down.fPressed) {
+#endif
             bool fMoved = false;
 
             for (short iMove = 0; iMove < iNumMoves; iMove++)
@@ -243,8 +248,12 @@ MenuCodeEnum MI_SelectField::SendInput(CPlayerInput * playerInput)
             if (fMoved)
                 return mcItemChangedCode;
         }
-
+#ifdef __SWITCH__
+        // prevent split joycon option from flickering when enabling/disabling split joycon mode
+        if (playerInput->outputControls[iPlayer].menu_left.fPressed) {
+#else
         if (playerInput->outputControls[iPlayer].menu_left.fPressed || playerInput->outputControls[iPlayer].menu_up.fPressed) {
+#endif
             bool fMoved = false;
 
             for (short iMove = 0; iMove < iNumMoves; iMove++)

--- a/src/smw/menu/PlayerControlsSelectMenu.cpp
+++ b/src/smw/menu/PlayerControlsSelectMenu.cpp
@@ -1,5 +1,10 @@
 #include "PlayerControlsSelectMenu.h"
 
+#ifdef __SWITCH__
+#include "GameValues.h"
+#include "ui/MI_SelectField.h"
+extern CGameValues game_values;
+#endif
 #include "ResourceManager.h"
 
 extern CResourceManager* rm;
@@ -18,6 +23,14 @@ UI_PlayerControlsSelectMenu::UI_PlayerControlsSelectMenu() : UI_Menu()
     miPlayer4ControlsButton = new MI_Button(&rm->spr_selectfield, 120, 260, "Player 4", 400, 1);
     miPlayer4ControlsButton->SetCode(MENU_CODE_TO_PLAYER_4_CONTROLS);
 
+#ifdef __SWITCH__
+    miPlayerControlsSingleJoyconModeField = new MI_SelectField(&rm->spr_selectfield, 120, 300, "Split Joycons", 400, 180);
+    miPlayerControlsSingleJoyconModeField->Add("Off", 0, "", false, false);
+    miPlayerControlsSingleJoyconModeField->Add("On", 1, "", true, false);
+    miPlayerControlsSingleJoyconModeField->SetData(NULL, NULL, &game_values.singleJoyconMode);
+    miPlayerControlsSingleJoyconModeField->SetKey(game_values.singleJoyconMode ? 1 : 0);
+#endif
+
     miPlayerControlsBackButton = new MI_Button(&rm->spr_selectfield, 544, 432, "Back", 80, 1);
     miPlayerControlsBackButton->SetCode(MENU_CODE_TO_MAIN_MENU);
 
@@ -28,8 +41,14 @@ UI_PlayerControlsSelectMenu::UI_PlayerControlsSelectMenu() : UI_Menu()
     AddControl(miPlayer1ControlsButton, miPlayerControlsBackButton, miPlayer2ControlsButton, NULL, miPlayerControlsBackButton);
     AddControl(miPlayer2ControlsButton, miPlayer1ControlsButton, miPlayer3ControlsButton, NULL, miPlayerControlsBackButton);
     AddControl(miPlayer3ControlsButton, miPlayer2ControlsButton, miPlayer4ControlsButton, NULL, miPlayerControlsBackButton);
+#ifdef __SWITCH__
+    AddControl(miPlayer4ControlsButton, miPlayer3ControlsButton, miPlayerControlsSingleJoyconModeField, NULL, miPlayerControlsBackButton);
+    AddControl(miPlayerControlsSingleJoyconModeField, miPlayer4ControlsButton, miPlayerControlsBackButton, NULL, miPlayerControlsBackButton);
+    AddControl(miPlayerControlsBackButton, miPlayerControlsSingleJoyconModeField, miPlayer1ControlsButton, miPlayer1ControlsButton, NULL);
+#else
     AddControl(miPlayer4ControlsButton, miPlayer3ControlsButton, miPlayerControlsBackButton, NULL, miPlayerControlsBackButton);
     AddControl(miPlayerControlsBackButton, miPlayer4ControlsButton, miPlayer1ControlsButton, miPlayer1ControlsButton, NULL);
+#endif
 
     AddNonControl(miPlayerControlsLeftHeaderBar);
     AddNonControl(miPlayerControlsMenuRightHeaderBar);

--- a/src/smw/menu/PlayerControlsSelectMenu.h
+++ b/src/smw/menu/PlayerControlsSelectMenu.h
@@ -4,6 +4,10 @@
 #include "uimenu.h"
 #include "uicontrol.h"
 
+#ifdef __SWITCH__
+class MI_SelectField;
+#endif
+
 /*
 	This menu leads to the control settings of player 1-4.
 */
@@ -18,6 +22,10 @@ private:
 	MI_Button * miPlayer2ControlsButton;
 	MI_Button * miPlayer3ControlsButton;
 	MI_Button * miPlayer4ControlsButton;
+
+#ifdef __SWITCH__
+	MI_SelectField * miPlayerControlsSingleJoyconModeField;
+#endif
 
 	MI_Button * miPlayerControlsBackButton;
 

--- a/src/smw/menu/options/GraphicsOptionsMenu.cpp
+++ b/src/smw/menu/options/GraphicsOptionsMenu.cpp
@@ -62,9 +62,21 @@ UI_GraphicsOptionsMenu::UI_GraphicsOptionsMenu() : UI_Menu()
     miFullscreenField->SetItemChangedCode(MENU_CODE_TOGGLE_FULLSCREEN);
 #endif //_XBOX
 
+#ifdef __SWITCH__
+    miFilteringField = new MI_SelectField(&rm->spr_selectfield, 70, 240, "Graphics Filter", 500, 220);
+    miFilteringField->Add("Point", 0, "", false, false);
+    miFilteringField->Add("Linear", 1, "", true, false);
+    miFilteringField->SetData(NULL, NULL, &game_values.filtering);
+    miFilteringField->SetKey(game_values.filtering ? 1 : 0);
+    miFilteringField->SetAutoAdvance(true);
+    miMenuGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 280, "Menu Graphics", 500, 220, menugraphicspacklist, MENU_CODE_MENU_GRAPHICS_PACK_CHANGED);
+    miWorldGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 320, "World Graphics", 500, 220, worldgraphicspacklist, MENU_CODE_WORLD_GRAPHICS_PACK_CHANGED);
+    miGameGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 360, "Game Graphics", 500, 220, gamegraphicspacklist, MENU_CODE_GAME_GRAPHICS_PACK_CHANGED);
+#else
     miMenuGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 240, "Menu Graphics", 500, 220, menugraphicspacklist, MENU_CODE_MENU_GRAPHICS_PACK_CHANGED);
     miWorldGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 280, "World Graphics", 500, 220, worldgraphicspacklist, MENU_CODE_WORLD_GRAPHICS_PACK_CHANGED);
     miGameGraphicsPackField = new MI_PacksField(&rm->spr_selectfield, 70, 320, "Game Graphics", 500, 220, gamegraphicspacklist, MENU_CODE_GAME_GRAPHICS_PACK_CHANGED);
+#endif
 
     miGraphicsOptionsMenuBackButton = new MI_Button(&rm->spr_selectfield, 544, 432, "Back", 80, 1);
     miGraphicsOptionsMenuBackButton->SetCode(MENU_CODE_BACK_TO_OPTIONS_MENU);
@@ -79,6 +91,11 @@ UI_GraphicsOptionsMenu::UI_GraphicsOptionsMenu() : UI_Menu()
     AddControl(miFrameLimiterField, miTopLayerField, miScreenSettingsButton, NULL, miGraphicsOptionsMenuBackButton);
     AddControl(miScreenSettingsButton, miFrameLimiterField, miMenuGraphicsPackField, NULL, miGraphicsOptionsMenuBackButton);
     AddControl(miMenuGraphicsPackField, miScreenSettingsButton, miWorldGraphicsPackField, NULL, miGraphicsOptionsMenuBackButton);
+#elif defined(__SWITCH__)
+    AddControl(miFrameLimiterField, miTopLayerField, miFullscreenField, NULL, miGraphicsOptionsMenuBackButton);
+    AddControl(miFullscreenField, miFrameLimiterField, miFilteringField, NULL, miGraphicsOptionsMenuBackButton);
+    AddControl(miFilteringField, miFullscreenField, miMenuGraphicsPackField, NULL, miGraphicsOptionsMenuBackButton);
+    AddControl(miMenuGraphicsPackField, miFilteringField, miWorldGraphicsPackField, NULL, miGraphicsOptionsMenuBackButton);
 #else
     AddControl(miFrameLimiterField, miTopLayerField, miFullscreenField, NULL, miGraphicsOptionsMenuBackButton);
     AddControl(miFullscreenField, miFrameLimiterField, miMenuGraphicsPackField, NULL, miGraphicsOptionsMenuBackButton);

--- a/src/smw/menu/options/GraphicsOptionsMenu.h
+++ b/src/smw/menu/options/GraphicsOptionsMenu.h
@@ -26,6 +26,10 @@ private:
     MI_SelectField * miFullscreenField;
 #endif //_XBOX
 
+#ifdef __SWITCH__
+    MI_SelectField * miFilteringField;
+#endif
+
     MI_PacksField * miMenuGraphicsPackField;
     MI_PacksField * miWorldGraphicsPackField;
     MI_PacksField * miGameGraphicsPackField;


### PR DESCRIPTION
This should allow the user to toggle single joycon mode by pressing R-Trigger on first controller.

Single joycon mode means that joycons will be automatically split when detached from Switch.

Pressing R again (on first player controller) should automatically combine the joycons again.

This is the same code as used in UAE4All2, that's why I think it should work without testing.

I cannot test it because I cannot compile your repo atm (some GitHub submodule problem with supermariowar-nx repo or something).
